### PR TITLE
Uniform config directory

### DIFF
--- a/assets/settings.pantheon.php
+++ b/assets/settings.pantheon.php
@@ -67,7 +67,7 @@ if ($is_installer_url) {
   $settings['config_sync_directory'] = 'sites/default/files';
 }
 else {
-  $settings['config_sync_directory'] = getenv('DOCROOT') ? '../config' : 'sites/default/config';
+  $settings['config_sync_directory'] = '../config';
 }
 
 


### PR DESCRIPTION
Do not support both the legacy and the recommended layout in this project; only support recommended (relocated docroot).