### PR TITLE
Avoid using the path "//tmp" on COE

### DIFF
--- a/assets/settings.pantheon.php
+++ b/assets/settings.pantheon.php
@@ -139,7 +139,7 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
  *
  */
 if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
-  $settings["file_temp_path"] = $_SERVER['HOME'] . '/tmp';
+  $settings["file_temp_path"] = sys_get_temp_dir();
 }
 
 /**


### PR DESCRIPTION
Noticed temporary path getting configured as `//tmp` after installing a custom distribution I'm working on that is using the scaffold files from this repo.  Copied change from pantheon-systems/drops-8#329.