### PR TITLE
Ignore settings.pantheon.php from PHP Code Sniffer

### DIFF
--- a/assets/settings.pantheon.php
+++ b/assets/settings.pantheon.php
@@ -1,5 +1,7 @@
 <?php
 
+// phpcs:ignoreFile
+
 /**
  * @file
  * Pantheon configuration file.


### PR DESCRIPTION
This removes the scaffolded `settings.pantheon.php` from PHPCS checks.

Alternatively, we could fix the sniff violations, but it's pretty common to just ignore settings files. Before this change, the same can be accomplished with these lines in `phpcs.xml`:
```xml
    <!-- Ignore scaffolded Pantheon settings file. -->
    <exclude-pattern>web/sites/default/settings.pantheon.php</exclude-pattern>
```
but it's better to have it taken care of upstream :) thank you! 🙏🏻