### PR TITLE
9.x: Set $settings['config_sync_directory'] only if it's empty

### DIFF
--- a/assets/settings.pantheon.php
+++ b/assets/settings.pantheon.php
@@ -65,11 +65,12 @@ $is_installer_url = (strpos($_SERVER['SCRIPT_NAME'], '/core/install.php') === 0)
  * at https://www.drupal.org/node/2431247
  *
  */
-if ($is_installer_url) {
-  $settings['config_sync_directory'] = 'sites/default/files';
-}
-else {
-  $settings['config_sync_directory'] = getenv('DOCROOT') ? '../config' : 'sites/default/config';
+if (empty($settings['config_sync_directory'])) {
+  if ($is_installer_url) {
+    $settings['config_sync_directory'] = 'sites/default/files';
+  } else {
+    $settings['config_sync_directory'] = getenv('DOCROOT') ? '../config' : 'sites/default/config';
+  }
 }
 
 


### PR DESCRIPTION
Copy of #25 for 9.x branch. Closes #24.