### PR TITLE
[SITE-3373] Stop scaffolding the settings.pantheon.php file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Then, Pantheon must be enabled from within your site's settings.php file:
 ```
 include \Pantheon\Integrations\Assets::dir() . "/settings.pantheon.php";
 ```
-This project must be enabled in the top-level composer.json file, or it will be ignored and will not perform any of its functions.
 
 ## Versions
 

--- a/README.md
+++ b/README.md
@@ -91,4 +91,12 @@ include __DIR__ . "/settings.pantheon.php";
 
 Replace the `__DIR__` on that line with `\Pantheon\Integrations\Assets::dir()`, as shown in the section "Enabling this project", above. Once you do this, the `settings.pantheon.php` file will no longer be copied into your site's configuration folder, and will instead be included directly from its installed location in the `vendor` directory. This should also cause the errors from the Drupal Package Manager to go away.
 
+The above steps can be done automatically via Terminus. (Note: Requires the [Terminus Composer plugin]().)
 
+```
+$ terminus connection:set sftp
+$ terminus composer update
+$ terminus drush ev '\Pantheon\Integrations\Utils::stopScaffolding();'
+$ terminus composer update
+$ terminus env:commit --message "Stop scaffolding Pantheon's Drupal integrations, and include directly from vendor instead."
+```

--- a/README.md
+++ b/README.md
@@ -2,14 +2,11 @@
 
 [![Actively Maintained](https://img.shields.io/badge/Pantheon-Actively_Maintained-yellow?logo=pantheon&color=FFDC28)](https://pantheon.io/docs/oss-support-levels#actively-maintained-support)
 
-Add this project to any Drupal distribution based on drupal/core-composer-scaffold to enable it for use on Pantheon.
+Add this project to any Composer-managed Drupal to enable it for use on Pantheon.
 
 This project enables the following Pantheon/Drupal integrations:
 
 - Injects the Pantheon database credentials for the Drupal site
-- Provides a default PHP version to use (7.3)
-- Enables HTTPS (in transitional mode) by default
-- Demonstrates how to turn on twig debugging on non-production Pantheon environments
 - Sets the path to:
   - Configuration import / export directory
   - Private files
@@ -17,30 +14,81 @@ This project enables the following Pantheon/Drupal integrations:
   - Twig cache files
 - Establishes a secure, random hash salt for Drupal
 - Injects the Pantheon Service Provider (clears edge cache on cache rebuild, etc.)
-- Prevents the user from updating Drupal core with Drush
 - Configures the trusted host patterns to avoid a warning that is not applicable to Panthoen
 - Ignores large cache directories (e.g. node modules and bower components)
 
 ## Enabling this project
 
+To enable this project, it must first be added to the Drupal site:
+
+```
+composer require pantheon-systems/drupal-integrations:^11
+```
+
+Then, Pantheon must be enabled from within your site's settings.php file:
+
+```
+include \Pantheon\Integrations\Assets::dir() . "/settings.pantheon.php";
+```
 This project must be enabled in the top-level composer.json file, or it will be ignored and will not perform any of its functions.
-```
-{
-    ...
-    "require": {
-        "pantheon-systems/drupal-integrations": "^9"
-    },
-    ...
-    "extra": {
-        "drupal-scaffold": {
-            "allowed-packages": [
-                "pantheon-systems/drupal-integrations"
-            ]
-        }
-    }
-}
-```
 
 ## Versions
 
-Use version "^8" for Drupal 8, and version "^9" for Drupal 9.
+Use the major version of this project that matches your Drupal version.
+
+| Drupal Version | drupal-integrations Version |
+| -------------- | --------------------------- |
+| 11.x           | ^11                         |
+| 10.x           | ^10                         |
+| 9.x            | ^9                          |
+| 8.x            | ^8                          |
+
+## Scaffolding
+
+Early versions of this project used the project drupal/core-composer-scaffold to copy the files needed into the right locations. Starting with Drupal 10.4, the scaffold extension is deprecated, and will cause the Drupal Package Manager to refuse to allow your site to be updated if it is allowed to scaffold files in your site's root composer.json file.
+
+If your site is still using the scaffolding feature, you will see the following error messages:
+
+```
+Unable to download modules via the UI: Any packages other than the implicitly allowed packages are not allowed to scaffold files. See the scaffold documentation for more information. pantheon-systems/drupal-integrations
+```
+
+and:
+
+```
+Your site cannot be automatically updated until further action is performed.
+
+Any packages other than the implicitly allowed packages are not allowed to scaffold files. See the scaffold documentation for more information.
+
+pantheon-systems/drupal-integrations
+```
+
+To fix this problem, first update to the latest version of pantheon-systems/drupal-integrations via `composer update`. Then, find the following section in your top-level composer.json file:
+
+```
+        "drupal-scaffold": {
+            "locations": {
+                "web-root": "./web"
+            },
+            "allowed-packages": [
+                "pantheon-systems/drupal-integrations"
+            ],
+            "file-mapping": {
+                "[project-root]/.editorconfig": false,
+                "[project-root]/pantheon.upstream.yml": false,
+                "[project-root]/.gitattributes": false
+            }
+        },
+```
+
+Delete the `allowed-packages` section. 
+
+Next, find the following line in your settings.php file:
+
+```
+include __DIR__ . "/settings.pantheon.php";
+```
+
+Replace the `__DIR__` on that line with `\Pantheon\Integrations\Assets::dir()`, as shown in the section "Enabling this project", above. Once you do this, the `settings.pantheon.php` file will no longer be copied into your site's configuration folder, and will instead be included directly from its installed location in the `vendor` directory. This should also cause the errors from the Drupal Package Manager to go away.
+
+

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This project enables the following Pantheon/Drupal integrations:
   - Twig cache files
 - Establishes a secure, random hash salt for Drupal
 - Injects the Pantheon Service Provider (clears edge cache on cache rebuild, etc.)
-- Configures the trusted host patterns to avoid a warning that is not applicable to Panthoen
+- Configures the trusted host patterns to avoid a warning that is not applicable to Pantheon
 - Ignores large cache directories (e.g. node modules and bower components)
 
 ## Enabling this project

--- a/assets/drush-lock-update
+++ b/assets/drush-lock-update
@@ -1,1 +1,0 @@
-Do not update via Drush. See: https://pantheon.io/docs/articles/sites/code/applying-upstream-updates/

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Pantheon\\Integrations\\": "src/",
+            "Pantheon\\Integrations\\": "src/"
         }
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,12 @@
     "type": "project",
     "license": "MIT",
     "conflict": {
-        "drupal/core": "<10"
+        "drupal/core": "<11"
+    },
+    "autoload": {
+        "psr-4": {
+            "Pantheon\\Integrations\\": "src/",
+        }
     },
     "extra": {
         "drupal-scaffold": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
     "extra": {
         "drupal-scaffold": {
             "file-mapping": {
-                "[project-root]/.drush-lock-update": "assets/drush-lock-update",
                 "[web-root]/sites/default/default.services.pantheon.preproduction.yml": "assets/default.services.pantheon.preproduction.yml",
                 "[web-root]/sites/default/settings.pantheon.php": "assets/settings.pantheon.php",
                 "[web-root]/sites/default/settings.php": {

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -14,7 +14,7 @@ class Assets {
 	 * @return string
 	 * 	 The asset directory path.
 	 */
-	public function dir(): string {
+	public static function dir(): string {
 		return dirname(__DIR__) . '/assets';
 	}
 }

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Pantheon\Integrations;
+
+/**
+ * The Assets class manages the assets needed to integrate a Drupal site with the Pantheon platform.
+ */
+class Assets {
+	/**
+	 * dir
+	 * 
+	 * Return the path to the assets directory.
+	 * 
+	 * @return string
+	 * 	 The asset directory path.
+	 */
+	public function dir(): string {
+		return dirname(__DIR__) . '/assets';
+	}
+}

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -13,7 +13,10 @@ class Utils {
 	 * 
 	 * Usage:
 	 * 
-	 * terminus drush ev '\Pantheon\Integrations\Utils::stopScaffolding();'
+	 *   terminus connection:set sftp
+	 *   terminus drush ev '\Pantheon\Integrations\Utils::stopScaffolding();'
+	 *   terminus composer update
+	 *   terminus env:commit --message "Stop scaffolding Pantheon's Drupal integrations, and include directly from vendor instead."
 	 * 
 	 * @return void
 	 */

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Pantheon\Integrations;
+
+/**
+ * The Utils class provides useful utility functions.
+ */
+class Utils {
+	/**
+	 * stopScaffolding
+	 * 
+	 * Remove scaffolding from the current site.
+	 * 
+	 * Usage:
+	 * 
+	 * terminus drush ev '\Pantheon\Integrations\Utils::stopScaffolding();'
+	 * 
+	 * @return void
+	 */
+	public static function stopScaffolding(): void {
+		$kernel = \Drupal::service("kernel");
+		$site_path = DRUPAL_ROOT . '/' . $kernel->getSitePath();
+		self::useSettingsFromVendor($site_path);
+
+		$composer_json_path = DRUPAL_ROOT . '/composer.json';
+		self::removePantheonScaffolding($composer_json_path);
+	}
+
+	/**
+	 * useSettingsFromVendor
+	 * 
+	 * Stop including settings.pantheon.php from the same directory
+	 * as settings.php, and instead load it directly from the vendor directory.
+	 * 
+	 * @return bool
+	 * 	TRUE if a replacement was done
+	 */
+	public static function useSettingsFromVendor($site_path): bool {
+		$settings_path = $site_path . '/settings.php';
+		$settings_contents = file_get_contents($settings_path);
+
+		$pantheon_settings_pattern = 'include __DIR__ . "/settings.pantheon.php";';
+		$include_from_vendor = 'include \Pantheon\Integrations\Assets::dir() . "/settings.pantheon.php";';
+
+		$updated_contents = str_replace($pantheon_settings_pattern, $include_from_vendor, $settings_contents);
+		if ($updated_contents == $settings_contents) {
+			return FALSE;
+		}
+		file_put_contents($settings_path, $updated_contents);
+		return TRUE;
+	}
+
+	/**
+	 * removePantheonScaffolding
+	 * 
+	 * Remove the directive that allows pantheon-systems/drupal-integrations to scaffold files.
+	 * 
+	 * @return bool
+	 *   TRUE if a replacement was done
+	 */
+	public static function removePantheonScaffolding($composer_json_path): bool {
+		$composer_json_contents = file_get_contents($composer_json_path);
+		$composer_data = json_decode($composer_json_contents, TRUE);
+
+		if (!isset($composer_data['extra']['drupal-scaffold']['allowed-packages'])) {
+			return FALSE;
+		}
+
+		// Find the index of the drupal-integrations entry in the allowed-packages array
+		$index = array_search('pantheon-systems/drupal-integrations', $composer_data['extra']['drupal-scaffold']['allowed-packages']);
+		if ($index === FALSE) {
+			return FALSE;
+		}
+	    unset($composer_data['extra']['drupal-scaffold']['allowed-packages'][$index]);
+	    if (empty($composer_data['extra']['drupal-scaffold']['allowed-packages'])) {
+	    	unset($composer_data['extra']['drupal-scaffold']['allowed-packages']);
+	    }
+
+	    // Write the updated composer.json file
+	    $composer_json_contents = static::jsonEncodePretty($composer_data);
+	    file_put_contents($composer_json_path, $composer_json_contents . PHP_EOL);
+	    return TRUE;
+	}
+
+	/**
+	 * jsonEncodePretty.
+	 *
+	 * Convert a nested array into a pretty-printed json-encoded string.
+	 * Multi-line arrays with a single entry are converted to single-line arrays.
+	 * 
+	 * @param array $data
+	 *   The data array to encode
+	 *
+	 * @return string
+	 *   The pretty-printed encoded string version of the supplied data.
+	 */
+	protected static function jsonEncodePretty(array $data): string {
+		$prettyContents = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+		$prettyContents = preg_replace('#": \[\s*("[^"]*")\s*\]#m', '": [\1]', $prettyContents);
+
+		return $prettyContents;
+	}
+}


### PR DESCRIPTION
This PR allows sites to opt-in to a new method for Pantheon to deliver Drupal integrations to Drupal sites. In the future, we will automate the removal of the scaffolding technique by way of the Composer pre-update script in the Drupal Composer Managed upstream.

Note that the instructions in this PR won't work yet, but the following interim steps probably will (n.b. Drupal 11 / Drupal CMS sites only):

```
$ terminus connection:set sftp
$ terminus composer require pantheon-systems/drupal-integrations:dev-stop-scaffolding
$ terminus drush ev '\Pantheon\Integrations\Utils::stopScaffolding();'
$ terminus composer update
$ terminus env:commit --message "Stop scaffolding Pantheon's Drupal integrations, and include directly from vendor instead."
```

This should remove the error messages:

```
Unable to download modules via the UI: Any packages other than the implicitly allowed packages are not allowed to scaffold files. See the scaffold documentation for more information. pantheon-systems/drupal-integrations
```

and:

```
Your site cannot be automatically updated until further action is performed.
Any packages other than the implicitly allowed packages are not allowed to scaffold files. See the scaffold documentation for more information.
pantheon-systems/drupal-integrations
```
