### PR TITLE
Fixing composer path for scaffolding

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -25,7 +25,7 @@ class Utils {
 		$site_path = DRUPAL_ROOT . '/' . $kernel->getSitePath();
 		self::useSettingsFromVendor($site_path);
 
-		$composer_json_path = DRUPAL_ROOT . '/composer.json';
+		$composer_json_path = DRUPAL_ROOT .  '/../composer.json';
 		self::removePantheonScaffolding($composer_json_path);
 	}
 


### PR DESCRIPTION
This change fixes the bug described in https://github.com/pantheon-systems/drupal-integrations/issues/38 although it seems oddly cumbersome to figure out the `DRUPAL_ROOT` and then go up a directory. I would expect there's a more straightforward way to determine the root composer.json.

I tested this change in a personal D11 project by:

Registering the fork at the root `composer.json`

```
composer config repositories.drupal-integrations vcs git@github.com:stevector-streaming/drupal-integrations.git
```

I updated the requirement to use the branch

```
composer require "pantheon-systems/drupal-integrations:dev-patch-1@dev"
```

And then I ran the command successfully
```
ddev drush ev '\Pantheon\Integrations\Utils::stopScaffolding();'
```