### PR TITLE
Disallow installation on Drupal 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "MIT",
     "conflict": {
-        "drupal/core": "<9"
+        "drupal/core": "<9 || >=11"
     },
     "extra": {
         "drupal-scaffold": {


### PR DESCRIPTION
While upgrading a site to Drupal 11 I ran into this error:

> [error]  ArgumentCountError: Too few arguments to function Drupal\Core\Cache\MemoryBackend::__construct(), 0 passed and exactly 1 expected in Drupal\Core\Cache\MemoryBackend->__construct() (line 38 of /code/core/lib/Drupal/Core/Cache/MemoryBackend.php) #0 [internal function]: Drupal\Core\Cache\MemoryBackend->__construct()

This turned out to step from pantheon-systems/drupal-integrations which was locked to v9 in the project's composer.json file. v9 currently indicates compatibility with all core releases from 9 onwards, so it doesn't indicate it's incompatibility with Drupal 11.

This merge request specifically indicates it is incompatible with core 11 or newer.