### PR TITLE
DELENG-444: Add catalog-info.yaml for Site Experience ownership

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: drupal-integrations
+  description: Critical repository for establishing compatibility between major Drupal versions and Pantheon
+  annotations:
+    github.com/project-slug: pantheon-systems/drupal-integrations
+  tags:
+    - drupal
+    - integration
+    - compatibility
+spec:
+  type: library
+  lifecycle: production
+  owner: site-experience


### PR DESCRIPTION
## Summary

Adds `catalog-info.yaml` to establish Site Experience ownership in the service catalog.

## Changes

- ✅ Added `catalog-info.yaml` for service catalog integration
- CODEOWNERS already correctly points to `@pantheon-systems/site-experience`

## Context

This repository is critical to the functioning of Drupal sites on Pantheon. It establishes compatibility between major Drupal versions and Pantheon. While activity is low between major Drupal releases (Drupal 11.0.0 was released April 2024), it will see more activity as we prepare for Drupal 12.

**Related:**
- Jira: [DELENG-444](https://getpantheon.atlassian.net/browse/DELENG-444)

## Verification

Ownership files follow pantheon-systems standards:
- CODEOWNERS already in place
- catalog-info.yaml follows Backstage spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DELENG-444]: https://getpantheon.atlassian.net/browse/DELENG-444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ